### PR TITLE
Fix scope availability of patch function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export default function h(tag, data) {
+function h (tag, data) {
   var node
   var stack = []
   var children = []
@@ -29,7 +29,7 @@ export default function h(tag, data) {
     : tag(data, children)
 }
 
-h.patch = function (parent, element, oldNode, node) {
+function patch (parent, element, oldNode, node) {
   if (oldNode == null) {
     element = parent.insertBefore(createElementFrom(node), element)
   } else if (node.tag && node.tag === oldNode.tag) {
@@ -204,3 +204,6 @@ function removeElement(parent, element, node) {
   }
   parent.removeChild(element)
 }
+
+h.patch = patch
+module.exports = h


### PR DESCRIPTION
Before, with patch as an attribute of h, patch was not
available to be called recursively. Fixed that, and also use
module.exports rather than es6 module export syntax, to make
it independent of babel-use